### PR TITLE
Feature/13 댓글 crud 구현

### DIFF
--- a/src/main/java/com/example/community/Post/domain/Post.java
+++ b/src/main/java/com/example/community/Post/domain/Post.java
@@ -73,4 +73,9 @@ public class Post extends BaseEntity {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void addComment(Comment comment) {
+        this.commentList.add(comment);
+        this.commentCount++;
+    }
 }

--- a/src/main/java/com/example/community/Post/domain/Post.java
+++ b/src/main/java/com/example/community/Post/domain/Post.java
@@ -55,7 +55,7 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member writer;
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
     @Builder.Default
@@ -77,5 +77,12 @@ public class Post extends BaseEntity {
     public void addComment(Comment comment) {
         this.commentList.add(comment);
         this.commentCount++;
+    }
+
+    public void removeComment(Comment comment) {
+        this.commentList.remove(comment);
+        if (this.commentCount > 0) {
+            this.commentCount--;
+        }
     }
 }

--- a/src/main/java/com/example/community/comment/api/CommentController.java
+++ b/src/main/java/com/example/community/comment/api/CommentController.java
@@ -2,14 +2,18 @@ package com.example.community.comment.api;
 
 import com.example.community.comment.api.dto.CreateCommentRequest;
 import com.example.community.comment.api.dto.CreateCommentResponse;
+import com.example.community.comment.api.dto.DeleteCommentResponse;
 import com.example.community.comment.application.mapper.CreateCommentMapper;
+import com.example.community.comment.application.mapper.DeleteCommentMapper;
 import com.example.community.comment.application.service.CommentService;
 import com.example.community.comment.domain.Comment;
 import com.example.community.global.response.ApiResponse;
 import com.example.community.global.response.code.status.SuccessStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,11 +26,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
     private final CommentService commentService;
 
-    @PostMapping("/{postId}")
+    @PostMapping("/{postId}/comment")
     public ApiResponse<CreateCommentResponse> createComment(HttpServletRequest httpServletRequest,
                                                             @RequestBody @Valid CreateCommentRequest createCommentRequest,
                                                             @PathVariable Long postId) {
         Comment comment = commentService.createComment(httpServletRequest, createCommentRequest, postId);
-        return ApiResponse.onSuccess(SuccessStatus.CREATE_COMMENT, CreateCommentMapper.toCreateCommentResponse(comment));
+        return ApiResponse.onSuccess(SuccessStatus.CREATE_COMMENT,
+                CreateCommentMapper.toCreateCommentResponse(comment));
+    }
+
+    @DeleteMapping("/{postId}/comment/{commentId}")
+    public ApiResponse<DeleteCommentResponse> deleteComment(HttpServletRequest httpServletRequest,
+                                                            @PathVariable Long postId,
+                                                            @PathVariable Long commentId) {
+        LocalDateTime deletedAt = commentService.deleteComment(httpServletRequest, postId, commentId);
+        return ApiResponse.onSuccess(SuccessStatus.DELETE_COMMENT,
+                DeleteCommentMapper.toDeleteCommentResponse(deletedAt));
     }
 }

--- a/src/main/java/com/example/community/comment/api/CommentController.java
+++ b/src/main/java/com/example/community/comment/api/CommentController.java
@@ -1,0 +1,32 @@
+package com.example.community.comment.api;
+
+import com.example.community.comment.api.dto.CreateCommentRequest;
+import com.example.community.comment.api.dto.CreateCommentResponse;
+import com.example.community.comment.application.mapper.CreateCommentMapper;
+import com.example.community.comment.application.service.CommentService;
+import com.example.community.comment.domain.Comment;
+import com.example.community.global.response.ApiResponse;
+import com.example.community.global.response.code.status.SuccessStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/post")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping("/{postId}")
+    public ApiResponse<CreateCommentResponse> createComment(HttpServletRequest httpServletRequest,
+                                                            @RequestBody @Valid CreateCommentRequest createCommentRequest,
+                                                            @PathVariable Long postId) {
+        Comment comment = commentService.createComment(httpServletRequest, createCommentRequest, postId);
+        return ApiResponse.onSuccess(SuccessStatus.CREATE_COMMENT, CreateCommentMapper.toCreateCommentResponse(comment));
+    }
+}

--- a/src/main/java/com/example/community/comment/api/CommentController.java
+++ b/src/main/java/com/example/community/comment/api/CommentController.java
@@ -1,12 +1,15 @@
 package com.example.community.comment.api;
 
+import com.example.community.comment.api.dto.CommentResponse;
 import com.example.community.comment.api.dto.CreateCommentRequest;
 import com.example.community.comment.api.dto.CreateCommentResponse;
 import com.example.community.comment.api.dto.DeleteCommentResponse;
+import com.example.community.comment.api.dto.GetCommentListResponse;
 import com.example.community.comment.api.dto.UpdateCommentRequest;
 import com.example.community.comment.api.dto.UpdateCommentResponse;
 import com.example.community.comment.application.mapper.CreateCommentMapper;
 import com.example.community.comment.application.mapper.DeleteCommentMapper;
+import com.example.community.comment.application.mapper.GetCommentMapper;
 import com.example.community.comment.application.mapper.UpdateCommentMapper;
 import com.example.community.comment.application.service.CommentService;
 import com.example.community.comment.domain.Comment;
@@ -15,14 +18,17 @@ import com.example.community.global.response.code.status.SuccessStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -57,5 +63,20 @@ public class CommentController {
         Comment comment = commentService.updateComment(httpServletRequest, updateCommentRequest, commentId);
         return ApiResponse.onSuccess(SuccessStatus.UPDATE_COMMENT,
                 UpdateCommentMapper.toUpdateCommentResponse(comment));
+    }
+
+    @GetMapping("/{postId}/comment")
+    public ApiResponse<GetCommentListResponse> getCommentList(HttpServletRequest httpServletRequest,
+                                                              @PathVariable Long postId,
+                                                              @RequestParam(defaultValue = "createdAt") String sort,
+                                                              @RequestParam(defaultValue = "5") int limit,
+                                                              @RequestParam(required = false)  LocalDateTime cursorCreatedAt,
+                                                              @RequestParam(required = false) Long cursorId
+                                                              ){
+        List<CommentResponse> commentResponseList = commentService.getCommentList(httpServletRequest, postId, sort,
+                limit, cursorCreatedAt, cursorId);
+
+        return ApiResponse.onSuccess(SuccessStatus.GET_COMMENT_LIST,
+                GetCommentMapper.toGetCommentListResponse(commentResponseList));
     }
 }

--- a/src/main/java/com/example/community/comment/api/CommentController.java
+++ b/src/main/java/com/example/community/comment/api/CommentController.java
@@ -3,8 +3,11 @@ package com.example.community.comment.api;
 import com.example.community.comment.api.dto.CreateCommentRequest;
 import com.example.community.comment.api.dto.CreateCommentResponse;
 import com.example.community.comment.api.dto.DeleteCommentResponse;
+import com.example.community.comment.api.dto.UpdateCommentRequest;
+import com.example.community.comment.api.dto.UpdateCommentResponse;
 import com.example.community.comment.application.mapper.CreateCommentMapper;
 import com.example.community.comment.application.mapper.DeleteCommentMapper;
+import com.example.community.comment.application.mapper.UpdateCommentMapper;
 import com.example.community.comment.application.service.CommentService;
 import com.example.community.comment.domain.Comment;
 import com.example.community.global.response.ApiResponse;
@@ -14,8 +17,10 @@ import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,5 +47,15 @@ public class CommentController {
         LocalDateTime deletedAt = commentService.deleteComment(httpServletRequest, postId, commentId);
         return ApiResponse.onSuccess(SuccessStatus.DELETE_COMMENT,
                 DeleteCommentMapper.toDeleteCommentResponse(deletedAt));
+    }
+
+    @PatchMapping("/{postId}/comment/{commentId}")
+    public ApiResponse<UpdateCommentResponse> updateComment(HttpServletRequest httpServletRequest,
+                                                            @RequestBody UpdateCommentRequest updateCommentRequest,
+                                                            @PathVariable Long postId,
+                                                            @PathVariable Long commentId) {
+        Comment comment = commentService.updateComment(httpServletRequest, updateCommentRequest, commentId);
+        return ApiResponse.onSuccess(SuccessStatus.UPDATE_COMMENT,
+                UpdateCommentMapper.toUpdateCommentResponse(comment));
     }
 }

--- a/src/main/java/com/example/community/comment/api/dto/CommentResponse.java
+++ b/src/main/java/com/example/community/comment/api/dto/CommentResponse.java
@@ -1,0 +1,15 @@
+package com.example.community.comment.api.dto;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long commentId,
+        String nickname,
+        String content,
+        String profileImage,
+        LocalDateTime updatedAt,
+        boolean isUpdated,
+        boolean viewerCanEdit,
+        boolean viewerCanDelete
+) {
+}

--- a/src/main/java/com/example/community/comment/api/dto/CreateCommentRequest.java
+++ b/src/main/java/com/example/community/comment/api/dto/CreateCommentRequest.java
@@ -1,0 +1,9 @@
+package com.example.community.comment.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCommentRequest(
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/example/community/comment/api/dto/CreateCommentResponse.java
+++ b/src/main/java/com/example/community/comment/api/dto/CreateCommentResponse.java
@@ -1,0 +1,9 @@
+package com.example.community.comment.api.dto;
+
+import java.time.LocalDateTime;
+
+public record CreateCommentResponse(
+        Long commentId,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/example/community/comment/api/dto/DeleteCommentResponse.java
+++ b/src/main/java/com/example/community/comment/api/dto/DeleteCommentResponse.java
@@ -1,0 +1,8 @@
+package com.example.community.comment.api.dto;
+
+import java.time.LocalDateTime;
+
+public record DeleteCommentResponse(
+        LocalDateTime deletedAt
+){
+}

--- a/src/main/java/com/example/community/comment/api/dto/GetCommentListResponse.java
+++ b/src/main/java/com/example/community/comment/api/dto/GetCommentListResponse.java
@@ -1,0 +1,11 @@
+package com.example.community.comment.api.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetCommentListResponse(
+        List<CommentResponse> commentList,
+        LocalDateTime nextCursorCreateAt,
+        Long nextCursorId
+) {
+}

--- a/src/main/java/com/example/community/comment/api/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/example/community/comment/api/dto/UpdateCommentRequest.java
@@ -1,0 +1,9 @@
+package com.example.community.comment.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCommentRequest(
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/example/community/comment/api/dto/UpdateCommentResponse.java
+++ b/src/main/java/com/example/community/comment/api/dto/UpdateCommentResponse.java
@@ -1,0 +1,9 @@
+package com.example.community.comment.api.dto;
+
+import java.time.LocalDateTime;
+
+public record UpdateCommentResponse(
+        Long commentId,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/example/community/comment/application/mapper/CreateCommentMapper.java
+++ b/src/main/java/com/example/community/comment/application/mapper/CreateCommentMapper.java
@@ -1,0 +1,21 @@
+package com.example.community.comment.application.mapper;
+
+import com.example.community.Post.domain.Post;
+import com.example.community.comment.api.dto.CreateCommentRequest;
+import com.example.community.comment.api.dto.CreateCommentResponse;
+import com.example.community.comment.domain.Comment;
+import com.example.community.member.domain.Member;
+
+public class CreateCommentMapper {
+    public static Comment toComment(CreateCommentRequest createCommentRequest, Member member, Post post) {
+        return Comment.builder()
+                .content(createCommentRequest.content())
+                .writer(member)
+                .post(post)
+                .build();
+    }
+
+    public static CreateCommentResponse toCreateCommentResponse(Comment comment) {
+        return new CreateCommentResponse(comment.getId(), comment.getCreatedAt());
+    }
+}

--- a/src/main/java/com/example/community/comment/application/mapper/DeleteCommentMapper.java
+++ b/src/main/java/com/example/community/comment/application/mapper/DeleteCommentMapper.java
@@ -1,0 +1,10 @@
+package com.example.community.comment.application.mapper;
+
+import com.example.community.comment.api.dto.DeleteCommentResponse;
+import java.time.LocalDateTime;
+
+public class DeleteCommentMapper {
+    public static DeleteCommentResponse toDeleteCommentResponse(LocalDateTime deletedAt) {
+        return new DeleteCommentResponse(deletedAt);
+    }
+}

--- a/src/main/java/com/example/community/comment/application/mapper/GetCommentMapper.java
+++ b/src/main/java/com/example/community/comment/application/mapper/GetCommentMapper.java
@@ -1,0 +1,22 @@
+package com.example.community.comment.application.mapper;
+
+import com.example.community.comment.api.dto.CommentResponse;
+import com.example.community.comment.api.dto.GetCommentListResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GetCommentMapper {
+    public static GetCommentListResponse toGetCommentListResponse(List<CommentResponse> commentResponseList) {
+        LocalDateTime nextCursorCreatedAt = null;
+        Long nextCursorId = null;
+
+        if (!commentResponseList.isEmpty()) {
+            CommentResponse last = commentResponseList.get(commentResponseList.size() - 1);
+
+            nextCursorCreatedAt = last.updatedAt();
+            nextCursorId = last.commentId();
+        }
+
+        return new GetCommentListResponse(commentResponseList, nextCursorCreatedAt, nextCursorId);
+    }
+}

--- a/src/main/java/com/example/community/comment/application/mapper/UpdateCommentMapper.java
+++ b/src/main/java/com/example/community/comment/application/mapper/UpdateCommentMapper.java
@@ -1,0 +1,10 @@
+package com.example.community.comment.application.mapper;
+
+import com.example.community.comment.api.dto.UpdateCommentResponse;
+import com.example.community.comment.domain.Comment;
+
+public class UpdateCommentMapper {
+    public static UpdateCommentResponse toUpdateCommentResponse(Comment comment) {
+        return new UpdateCommentResponse(comment.getId(), comment.getUpdatedAt());
+    }
+}

--- a/src/main/java/com/example/community/comment/application/service/CommentService.java
+++ b/src/main/java/com/example/community/comment/application/service/CommentService.java
@@ -1,0 +1,9 @@
+package com.example.community.comment.application.service;
+
+import com.example.community.comment.api.dto.CreateCommentRequest;
+import com.example.community.comment.domain.Comment;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface CommentService {
+    Comment createComment(HttpServletRequest httpServletRequest, CreateCommentRequest createCommentRequest, Long postId);
+}

--- a/src/main/java/com/example/community/comment/application/service/CommentService.java
+++ b/src/main/java/com/example/community/comment/application/service/CommentService.java
@@ -3,7 +3,11 @@ package com.example.community.comment.application.service;
 import com.example.community.comment.api.dto.CreateCommentRequest;
 import com.example.community.comment.domain.Comment;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
 
 public interface CommentService {
-    Comment createComment(HttpServletRequest httpServletRequest, CreateCommentRequest createCommentRequest, Long postId);
+    Comment createComment(HttpServletRequest httpServletRequest, CreateCommentRequest createCommentRequest,
+                          Long postId);
+
+    LocalDateTime deleteComment(HttpServletRequest httpServletRequest, Long postId, Long commentId);
 }

--- a/src/main/java/com/example/community/comment/application/service/CommentService.java
+++ b/src/main/java/com/example/community/comment/application/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.example.community.comment.application.service;
 
 import com.example.community.comment.api.dto.CreateCommentRequest;
+import com.example.community.comment.api.dto.UpdateCommentRequest;
 import com.example.community.comment.domain.Comment;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
@@ -10,4 +11,7 @@ public interface CommentService {
                           Long postId);
 
     LocalDateTime deleteComment(HttpServletRequest httpServletRequest, Long postId, Long commentId);
+
+    Comment updateComment(HttpServletRequest httpServletRequest, UpdateCommentRequest updateCommentRequest,
+                          Long commentId);
 }

--- a/src/main/java/com/example/community/comment/application/service/CommentService.java
+++ b/src/main/java/com/example/community/comment/application/service/CommentService.java
@@ -1,10 +1,12 @@
 package com.example.community.comment.application.service;
 
+import com.example.community.comment.api.dto.CommentResponse;
 import com.example.community.comment.api.dto.CreateCommentRequest;
 import com.example.community.comment.api.dto.UpdateCommentRequest;
 import com.example.community.comment.domain.Comment;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface CommentService {
     Comment createComment(HttpServletRequest httpServletRequest, CreateCommentRequest createCommentRequest,
@@ -14,4 +16,8 @@ public interface CommentService {
 
     Comment updateComment(HttpServletRequest httpServletRequest, UpdateCommentRequest updateCommentRequest,
                           Long commentId);
+
+    List<CommentResponse> getCommentList(HttpServletRequest httpServletRequest, Long postId, String sort,
+                                         int limit, LocalDateTime cursorCreatedAt,
+                                         Long cursorId);
 }

--- a/src/main/java/com/example/community/comment/application/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/community/comment/application/service/CommentServiceImpl.java
@@ -4,7 +4,9 @@ import com.example.community.Post.domain.Post;
 import com.example.community.Post.exception.PostNotFoundException;
 import com.example.community.Post.repository.PostRepository;
 import com.example.community.auth.jwt.JwtUtils;
+import com.example.community.comment.api.dto.CommentResponse;
 import com.example.community.comment.api.dto.CreateCommentRequest;
+import com.example.community.comment.api.dto.GetCommentListResponse;
 import com.example.community.comment.api.dto.UpdateCommentRequest;
 import com.example.community.comment.application.mapper.CreateCommentMapper;
 import com.example.community.comment.domain.Comment;
@@ -17,6 +19,7 @@ import com.example.community.member.exception.MemberNotFoundException;
 import com.example.community.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,4 +81,16 @@ public class CommentServiceImpl implements CommentService {
 
         return comment;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentList(HttpServletRequest httpServletRequest, Long postId, String sort,
+                                                int limit, LocalDateTime cursorCreatedAt,
+                                                Long cursorId) {
+        String accessToken = jwtUtils.resolveToken(httpServletRequest);
+        Long memberId = Long.parseLong(jwtUtils.getUserNameFromToken(accessToken));
+
+        return commentRepository.getCommentListWithCursor(memberId, postId, sort, limit, cursorCreatedAt, cursorId);
+    }
+
 }

--- a/src/main/java/com/example/community/comment/application/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/community/comment/application/service/CommentServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.community.Post.exception.PostNotFoundException;
 import com.example.community.Post.repository.PostRepository;
 import com.example.community.auth.jwt.JwtUtils;
 import com.example.community.comment.api.dto.CreateCommentRequest;
+import com.example.community.comment.api.dto.UpdateCommentRequest;
 import com.example.community.comment.application.mapper.CreateCommentMapper;
 import com.example.community.comment.domain.Comment;
 import com.example.community.comment.exception.CommentNotFoundException;
@@ -60,5 +61,21 @@ public class CommentServiceImpl implements CommentService {
         commentRepository.delete(comment);
 
         return LocalDateTime.now();
+    }
+
+    @Override
+    @Transactional
+    public Comment updateComment(HttpServletRequest httpServletRequest, UpdateCommentRequest updateCommentRequest,
+                                 Long commentId) {
+        String accessToken = jwtUtils.resolveToken(httpServletRequest);
+        Long memberId = Long.parseLong(jwtUtils.getUserNameFromToken(accessToken));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
+
+        if (!comment.getWriter().getId().equals(memberId)) {
+            throw new GeneralException(ErrorStatus.NO_PERMISSION);
+        }
+        comment.updateContent(updateCommentRequest.content());
+
+        return comment;
     }
 }

--- a/src/main/java/com/example/community/comment/domain/Comment.java
+++ b/src/main/java/com/example/community/comment/domain/Comment.java
@@ -12,11 +12,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Comment extends BaseEntity {
@@ -30,7 +32,7 @@ public class Comment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")

--- a/src/main/java/com/example/community/comment/domain/Comment.java
+++ b/src/main/java/com/example/community/comment/domain/Comment.java
@@ -37,4 +37,8 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/example/community/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/example/community/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.community.comment.exception;
+
+import com.example.community.global.exception.GeneralException;
+import com.example.community.global.response.code.status.ErrorStatus;
+
+public class CommentNotFoundException extends GeneralException {
+    public CommentNotFoundException() {
+        super(ErrorStatus.COMMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/community/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.community.comment.repository;
+
+import com.example.community.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/community/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/community/comment/repository/CommentRepository.java
@@ -3,5 +3,5 @@ package com.example.community.comment.repository;
 import com.example.community.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 }

--- a/src/main/java/com/example/community/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/example/community/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.community.comment.repository;
+
+import com.example.community.comment.api.dto.CommentResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    List<CommentResponse> getCommentListWithCursor(Long viewerId, Long postId, String sort, int limit, LocalDateTime cursorCreatedAt,
+                                                   Long cursorId);
+}

--- a/src/main/java/com/example/community/comment/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/example/community/comment/repository/CommentRepositoryCustomImpl.java
@@ -1,0 +1,96 @@
+package com.example.community.comment.repository;
+
+import com.example.community.Post.domain.QPost;
+import com.example.community.comment.api.dto.CommentResponse;
+import com.example.community.comment.domain.QComment;
+import com.example.community.image.domain.QImage;
+import com.example.community.member.domain.QMember;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private final QMember writer = QMember.member;
+    private final QImage profileImage = QImage.image;
+    private final QComment comment = QComment.comment;
+
+    @Override
+    public List<CommentResponse> getCommentListWithCursor(Long viewerId, Long postId, String sort, int limit, LocalDateTime cursorCreatedAt,
+                                                          Long cursorId) {
+        BooleanExpression cursorCondition = buildCursorCondition(sort, cursorCreatedAt, cursorId);
+        OrderSpecifier<?>[] orderSpecifier = buildOrderSpecifier(sort);
+        return queryFactory
+                .select(Projections.constructor(
+                        CommentResponse.class,
+                        comment.id,
+                        writer.nickname,
+                        comment.content,
+                        profileImage.objectKey,                     // 작성자 프로필 이미지
+                        comment.updatedAt,                          // 수정된 시각
+                        comment.createdAt.ne(comment.updatedAt),    // 생성시간과 수정시간이 다르면 수정된 것
+                        writer.id.eq(viewerId)
+                                .as("viewerCanEdit"),
+                        writer.id.eq(viewerId)
+                                .as("viewerCanDelete")
+                ))
+                .from(comment)
+                .join(comment.writer, writer)
+                .leftJoin(writer.profileImage, profileImage)
+                .where(comment.post.id.eq(postId),
+                        cursorCondition)
+                .orderBy(orderSpecifier)
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression buildCursorCondition(String sort, LocalDateTime cursorCreatedAt, Long cursorId) {
+
+        if (cursorCreatedAt == null || cursorId == null) {
+            return null; // 첫 페이지 요청
+        }
+
+        switch (sort) {
+            case "latest":
+                // 최신순 (createdAt DESC, id DESC)
+                return comment.createdAt.lt(cursorCreatedAt)
+                        .or(comment.createdAt.eq(cursorCreatedAt).and(comment.id.lt(cursorId)));
+
+            case "oldest":
+                // 등록순 (createdAt ASC, id ASC)
+                return comment.createdAt.gt(cursorCreatedAt)
+                        .or(comment.createdAt.eq(cursorCreatedAt).and(comment.id.gt(cursorId)));
+
+            default:
+                return null;
+        }
+    }
+
+    private OrderSpecifier<?>[] buildOrderSpecifier(String sort) {
+        switch (sort) {
+            case "latest":
+                return new OrderSpecifier[]{
+                        new OrderSpecifier<>(Order.DESC, comment.createdAt),
+                        new OrderSpecifier<>(Order.DESC, comment.id)
+                };
+            case "oldest":
+                return new OrderSpecifier[]{
+                        new OrderSpecifier<>(Order.ASC, comment.createdAt),
+                        new OrderSpecifier<>(Order.ASC, comment.id)
+                };
+            default:
+                return new OrderSpecifier[]{
+                        new OrderSpecifier<>(Order.DESC, comment.createdAt),
+                        new OrderSpecifier<>(Order.DESC, comment.id)
+                };
+        }
+    }
+}

--- a/src/main/java/com/example/community/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/ErrorStatus.java
@@ -39,6 +39,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "404_002", "사용자 정보가 존재하지 않습니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "404_003", "이미지가 존재하지 않습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "404_004", "게시글이 존재하지 않습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "404_005", "댓글이 존재하지 않습니다."),
 
 
     // 409 CONFLICT

--- a/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
@@ -28,7 +28,8 @@ public enum SuccessStatus implements BaseCode {
     DELETE_POST(HttpStatus.OK,"200_013", "게시글이 삭제되었습니다."),
     UPDATE_POST(HttpStatus.OK,"200_014", "게시글이 수정되었습니다."),
     GET_POST_LIST(HttpStatus.OK,"200_015", "게시글 목록을 조회하였습니다."),
-    GET_POST(HttpStatus.OK,"200_016", "게시글을 조회하였습니다.")
+    GET_POST(HttpStatus.OK,"200_016", "게시글을 조회하였습니다."),
+    CREATE_COMMENT(HttpStatus.OK,"200_017", "댓글을 생성하였습니다."),
     ;
 
 

--- a/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus implements BaseCode {
     GET_POST_LIST(HttpStatus.OK,"200_015", "게시글 목록을 조회하였습니다."),
     GET_POST(HttpStatus.OK,"200_016", "게시글을 조회하였습니다."),
     CREATE_COMMENT(HttpStatus.OK,"200_017", "댓글을 생성하였습니다."),
+    DELETE_COMMENT(HttpStatus.OK,"200_018", "댓글을 삭제하였습니다."),
     ;
 
 

--- a/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
@@ -31,6 +31,7 @@ public enum SuccessStatus implements BaseCode {
     GET_POST(HttpStatus.OK,"200_016", "게시글을 조회하였습니다."),
     CREATE_COMMENT(HttpStatus.OK,"200_017", "댓글을 생성하였습니다."),
     DELETE_COMMENT(HttpStatus.OK,"200_018", "댓글을 삭제하였습니다."),
+    UPDATE_COMMENT(HttpStatus.OK,"200_019", "댓글을 수정하였습니다."),
     ;
 
 

--- a/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
@@ -32,6 +32,7 @@ public enum SuccessStatus implements BaseCode {
     CREATE_COMMENT(HttpStatus.OK,"200_017", "댓글을 생성하였습니다."),
     DELETE_COMMENT(HttpStatus.OK,"200_018", "댓글을 삭제하였습니다."),
     UPDATE_COMMENT(HttpStatus.OK,"200_019", "댓글을 수정하였습니다."),
+    GET_COMMENT_LIST(HttpStatus.OK,"200_020", "댓글 목록을 조회하였습니다."),
     ;
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#13 

## 📝 작업 내용
- 댓글 생성
- 댓글 수정
- 댓글 삭제
- 댓글 목록 조회
  - 생성일자와 commentId를 복합 커서로 사용하여 동일한 생성일자로 인해 중복되는 데이터가 누락될 위험을 제거하였음.



### 스크린샷 (선택)