### PR TITLE
Feat: 리프레시 토큰 재발급 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
     //	Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/example/community/auth/Exception/TokenNotFoundException.java
+++ b/src/main/java/com/example/community/auth/Exception/TokenNotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.community.auth.Exception;
+
+import com.example.community.global.exception.GeneralException;
+import com.example.community.global.response.code.status.ErrorStatus;
+
+public class TokenNotFoundException extends GeneralException {
+    public TokenNotFoundException() {
+        super(ErrorStatus.TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/example/community/auth/api/AuthController.java
+++ b/src/main/java/com/example/community/auth/api/AuthController.java
@@ -1,8 +1,10 @@
 package com.example.community.auth.api;
 
+import com.example.community.auth.Exception.TokenNotFoundException;
 import com.example.community.auth.api.dto.LoginRequest;
 import com.example.community.auth.api.dto.LoginResponse;
 import com.example.community.auth.api.dto.LogoutResponse;
+import com.example.community.auth.api.dto.RefreshResponse;
 import com.example.community.auth.application.service.AuthService;
 import com.example.community.global.response.ApiResponse;
 import com.example.community.global.response.code.status.SuccessStatus;
@@ -11,6 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,5 +49,29 @@ public class AuthController {
     public ApiResponse<LogoutResponse> logout(HttpServletRequest request) {
         LogoutResponse response = authService.logout(request);
         return ApiResponse.onSuccess(SuccessStatus.LOGOUT_SUCCESS, response);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<RefreshResponse> refresh(
+            @CookieValue(value = "refresh_token", required = false) String refreshToken,
+            HttpServletResponse httpServletResponse) {
+
+        if (refreshToken == null) {
+            throw new TokenNotFoundException();
+        }
+
+        RefreshResponse refreshResponse = authService.refresh(refreshToken);
+        String newRefreshToken = refreshResponse.refreshToken();
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", newRefreshToken)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)
+                .sameSite("None")
+                .secure(false)
+                .build();
+        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ApiResponse.onSuccess(SuccessStatus.REFRESH_SUCCESS, refreshResponse);
     }
 }

--- a/src/main/java/com/example/community/auth/api/AuthController.java
+++ b/src/main/java/com/example/community/auth/api/AuthController.java
@@ -7,7 +7,10 @@ import com.example.community.auth.application.service.AuthService;
 import com.example.community.global.response.ApiResponse;
 import com.example.community.global.response.code.status.SuccessStatus;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,8 +25,20 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping
-    public ApiResponse<LoginResponse> login(@RequestBody LoginRequest request) {
+    public ApiResponse<LoginResponse> login(@RequestBody LoginRequest request,
+                                            HttpServletResponse httpServletResponse) {
         LoginResponse loginResponse = authService.login(request);
+        String refreshToken = loginResponse.refreshToken();
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true) //  클라이언트나 스크립트에서 조작하지 못하도록 함
+                .secure(false)                // 운영환경(HTTPS)에서는 true
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)   // 7일
+                .sameSite("None")
+                .secure(false)  // localhost에서만 예외 허용
+                .build();
+        httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
         return ApiResponse.onSuccess(SuccessStatus.LOGIN_SUCCESS, loginResponse);
     }
 

--- a/src/main/java/com/example/community/auth/api/dto/LoginResponse.java
+++ b/src/main/java/com/example/community/auth/api/dto/LoginResponse.java
@@ -1,9 +1,14 @@
 package com.example.community.auth.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record LoginResponse(
         Long memberId,
         String nickname,
         String accessToken,
+
+        //  컨트롤러에서 읽을 수 있지만, 직렬화에서 제외함으로써 브라우저 body에 노출시키지 않는다.
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
         String refreshToken
 ) {
 }

--- a/src/main/java/com/example/community/auth/api/dto/RefreshResponse.java
+++ b/src/main/java/com/example/community/auth/api/dto/RefreshResponse.java
@@ -1,0 +1,12 @@
+package com.example.community.auth.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record RefreshResponse(
+        String accessToken,
+
+        //  컨트롤러에서 읽을 수 있지만, 직렬화에서 제외함으로써 브라우저 body에 노출시키지 않는다.
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/community/auth/application/mapper/RefreshMapper.java
+++ b/src/main/java/com/example/community/auth/application/mapper/RefreshMapper.java
@@ -1,0 +1,10 @@
+package com.example.community.auth.application.mapper;
+
+import com.example.community.auth.api.dto.RefreshResponse;
+import com.example.community.auth.jwt.JwtToken;
+
+public class RefreshMapper {
+    public static RefreshResponse toRefreshResponse(JwtToken jwtToken) {
+        return new RefreshResponse(jwtToken.getAccessToken(), jwtToken.getRefreshToken());
+    }
+}

--- a/src/main/java/com/example/community/auth/application/service/AuthService.java
+++ b/src/main/java/com/example/community/auth/application/service/AuthService.java
@@ -3,10 +3,13 @@ package com.example.community.auth.application.service;
 import com.example.community.auth.api.dto.LoginRequest;
 import com.example.community.auth.api.dto.LoginResponse;
 import com.example.community.auth.api.dto.LogoutResponse;
+import com.example.community.auth.api.dto.RefreshResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthService {
-    public LoginResponse login(LoginRequest request);
+    LoginResponse login(LoginRequest request);
 
-    public LogoutResponse logout(HttpServletRequest request);
+    LogoutResponse logout(HttpServletRequest request);
+
+    RefreshResponse refresh(String refreshToken);
 }

--- a/src/main/java/com/example/community/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/community/auth/application/service/AuthServiceImpl.java
@@ -4,8 +4,10 @@ import com.example.community.auth.Exception.LoginFailedException;
 import com.example.community.auth.api.dto.LoginRequest;
 import com.example.community.auth.api.dto.LoginResponse;
 import com.example.community.auth.api.dto.LogoutResponse;
+import com.example.community.auth.api.dto.RefreshResponse;
 import com.example.community.auth.application.mapper.LoginMapper;
 import com.example.community.auth.application.mapper.LogoutMapper;
+import com.example.community.auth.application.mapper.RefreshMapper;
 import com.example.community.auth.jwt.JwtToken;
 import com.example.community.auth.jwt.JwtUtils;
 import com.example.community.global.redis.RedisDao;
@@ -15,10 +17,14 @@ import com.example.community.member.exception.MemberNotFoundException;
 import com.example.community.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -42,7 +48,10 @@ public class AuthServiceImpl implements AuthService {
             throw new LoginFailedException();
         }
 
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, rawPassword);
+        //  Spring Security 인증용 토큰
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email,
+                rawPassword);
+
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         JwtToken jwtToken = jwtUtils.generateToken(authentication);
         return LoginMapper.toLoginResponse(member, jwtToken);
@@ -59,6 +68,28 @@ public class AuthServiceImpl implements AuthService {
         redisDao.setValues("blacklist:" + accessToken, "logout", Duration.ofMillis(remainingTime));
 
         return LogoutMapper.toLogoutResponse();
+    }
+
+    /**
+     * accessToken이 만료된 사용자가 토큰 재발급 요청을 보내면, access, refresh 토큰 모두 재발급한다.
+     *
+     * @param refreshToken: accessToken이 만료된 사용자의 refreshToken
+     * @return RefreshResponse: accessToken, refreshToken
+     */
+    @Override
+    public RefreshResponse refresh(String refreshToken) {
+        jwtUtils.validateRefreshToken(refreshToken);
+        String memberId = jwtUtils.getUserNameFromToken(refreshToken);
+
+        // redis에 저장된 기존 refreshToken 제거
+        jwtUtils.deleteRefreshToken(memberId);
+
+        // Authentication 객체를 직접 생성
+        Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(memberId, null, authorities);
+
+        JwtToken newToken = jwtUtils.generateToken(authentication);
+        return RefreshMapper.toRefreshResponse(newToken);
     }
 
 }

--- a/src/main/java/com/example/community/global/config/CorsConfig.java
+++ b/src/main/java/com/example/community/global/config/CorsConfig.java
@@ -1,0 +1,40 @@
+package com.example.community.global.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CorsConfig {
+    public static CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        //리소스를 허용할 URL 지정
+        ArrayList<String> allowedOriginPatterns = new ArrayList<>();
+        allowedOriginPatterns.add("http://localhost:3000");
+        allowedOriginPatterns.add("http://127.0.0.1:3000");
+        configuration.setAllowedOrigins(allowedOriginPatterns);
+
+        //허용하는 HTTP METHOD 지정
+        ArrayList<String> allowedHttpMethods = new ArrayList<>();
+        allowedHttpMethods.add("GET");
+        allowedHttpMethods.add("POST");
+        allowedHttpMethods.add("PATCH");
+        allowedHttpMethods.add("DELETE");
+        configuration.setAllowedMethods(allowedHttpMethods);
+
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+
+        //인증, 인가를 위한 credentials 를 TRUE로 설정
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/example/community/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/community/global/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)  // 기본 로그인 폼 비활성화
                 .httpBasic(AbstractHttpConfigurer::disable)  // 기본 HTTP Basic 인증 비활성화
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(CorsConfig.corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/auth").permitAll()          // 로그인
                         .requestMatchers(HttpMethod.POST, "/member").permitAll()        // 회원가입

--- a/src/main/java/com/example/community/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/ErrorStatus.java
@@ -40,6 +40,7 @@ public enum ErrorStatus implements BaseErrorCode {
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "404_003", "이미지가 존재하지 않습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "404_004", "게시글이 존재하지 않습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "404_005", "댓글이 존재하지 않습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "404_006", "토큰이 존재하지 않습니다."),
 
 
     // 409 CONFLICT

--- a/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/community/global/response/code/status/SuccessStatus.java
@@ -33,6 +33,8 @@ public enum SuccessStatus implements BaseCode {
     DELETE_COMMENT(HttpStatus.OK,"200_018", "댓글을 삭제하였습니다."),
     UPDATE_COMMENT(HttpStatus.OK,"200_019", "댓글을 수정하였습니다."),
     GET_COMMENT_LIST(HttpStatus.OK,"200_020", "댓글 목록을 조회하였습니다."),
+    REFRESH_SUCCESS(HttpStatus.OK,"200_021", "토큰을 재발급하였습니다."),
+
     ;
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x

## 📝 작업 내용
클라이언트의 Access Token 만료시, Refresh Token으로 재발급할 수 있는 API를 구현. 
요청 시 Access, Refresh Token 모두 재발급
<img width="856" height="725" alt="image" src="https://github.com/user-attachments/assets/74433f8d-cde4-4d92-bced-a3ed6eec2e41" />

<img width="900" height="951" alt="image" src="https://github.com/user-attachments/assets/a9f7a5ea-7e15-40ac-866f-581fddd253ce" />



### 스크린샷 (선택)